### PR TITLE
Add CI to run pytest on pushes and PRs

### DIFF
--- a/mlops-introduction/.github/workflows/tests.yml
+++ b/mlops-introduction/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: python -m pytest -q


### PR DESCRIPTION
- Adds GitHub Actions workflow to run pytest automatically on pushes and pull requests
- Ensures tests are checked before merging
- Builds on earlier pytest config and test suite

